### PR TITLE
improve win async race by not opening window for watchdog process

### DIFF
--- a/lib/ansible/modules/windows/async_wrapper.ps1
+++ b/lib/ansible/modules/windows/async_wrapper.ps1
@@ -404,6 +404,8 @@ Function Start-Watchdog {
 
     $watchdog_pid = $pi.dwProcessId
 
+    Sleep -Seconds 2 # FUTURE: figure out race that's causing the last watchdog in a loop to die
+
     return $watchdog_pid
 }
 


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
async_wrapper.ps1

##### SUMMARY
Improve async startup race by not creating a window for the watchdog process